### PR TITLE
Change Athena join query for ADF mode

### DIFF
--- a/reinforcement_learning/bandits_recsys_movielens/src/train-vw.py
+++ b/reinforcement_learning/bandits_recsys_movielens/src/train-vw.py
@@ -97,7 +97,7 @@ def main():
                 continue
             vw_model.learn(user_embedding=json.loads(experience.get("shared_context", "null")),
                            candidate_embeddings=json.loads(experience.get("actions_context", "null")),
-                           action_index=experience["action"],
+                           action_index=int(experience["action"]),
                            reward=experience["reward"],
                            action_prob=experience["action_prob"],
                            user_id=experience["user_id"])


### PR DESCRIPTION
Change Athena join queries to allow for multiple experience instances per endpoing hit.

`user_id` is now an attribute of `obs_table`, could possibly comes with `reward_table` if added at https://github.com/aws/sagemaker-rl-container/blob/adf/src/vw-serving/src/vw_serving/serve.py#L471. 

Tested under SM mode.

**This change is not backward compatible.**